### PR TITLE
use dumb-init as PID 1

### DIFF
--- a/adminer-dg/Dockerfile
+++ b/adminer-dg/Dockerfile
@@ -18,7 +18,8 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         php7-mysqli@community \
         php7-pgsql@testing \
         php7-json@testing \
-        php7-pecl-mongodb@testing && \
+        php7-pecl-mongodb@testing \
+        dumb-init && \
     wget https://github.com/dg/adminer-custom/archive/v$ADMINER_DG_VERION.tar.gz -O /srv/adminer.tgz && \
     tar zxvf /srv/adminer.tgz --strip-components=1 -C /srv && \
     rm /srv/adminer.tgz && \
@@ -27,6 +28,8 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
 
 WORKDIR /srv
 EXPOSE 80
+
+ENTRYPOINT ["dumb-init", "--"]
 
 CMD /usr/bin/php \
     -d memory_limit=$MEMORY \

--- a/adminer-editor/Dockerfile
+++ b/adminer-editor/Dockerfile
@@ -17,13 +17,16 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         php7-session@testing \
         php7-mysqli@community \
         php7-pgsql@testing \
-        php7-pecl-mongodb@testing && \
+        php7-pecl-mongodb@testing \
+        dumb-init && \
     wget https://github.com/vrana/adminer/releases/download/v$ADMINER_EDITOR_VERSION/editor-$ADMINER_EDITOR_VERSION.php -O /srv/index.php && \
     apk del wget ca-certificates && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /srv
 EXPOSE 80
+
+ENTRYPOINT ["dumb-init", "--"]
 
 CMD /usr/bin/php \
     -d memory_limit=$MEMORY \

--- a/adminer-full/Dockerfile
+++ b/adminer-full/Dockerfile
@@ -18,13 +18,16 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         php7-mysqli@community \
         php7-pgsql@testing \
         php7-json@testing \
-        php7-pecl-mongodb@testing && \
+        php7-pecl-mongodb@testing \
+        dumb-init && \
         wget https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php -O /srv/index.php && \
     apk del wget ca-certificates && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /srv
 EXPOSE 80
+
+ENTRYPOINT ["dumb-init", "--"]
 
 CMD /usr/bin/php \
     -d memory_limit=$MEMORY \

--- a/adminer-mongo/Dockerfile
+++ b/adminer-mongo/Dockerfile
@@ -15,13 +15,16 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         ca-certificates \
         php7@testing \
         php7-session@testing \
-        php7-pecl-mongodb@testing && \
+        php7-pecl-mongodb@testing \
+        dumb-init && \
     wget https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php -O /srv/index.php && \
     apk del wget ca-certificates && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /srv
 EXPOSE 80
+
+ENTRYPOINT ["dumb-init", "--"]
 
 CMD /usr/bin/php \
     -d memory_limit=$MEMORY \

--- a/adminer-mysql/Dockerfile
+++ b/adminer-mysql/Dockerfile
@@ -15,13 +15,16 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         ca-certificates \
         php7@testing \
         php7-session@testing \
-        php7-mysqli@testing && \
+        php7-mysqli@testing \
+        dumb-init && \
     wget https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php -O /srv/index.php && \
     apk del wget ca-certificates && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /srv
 EXPOSE 80
+
+ENTRYPOINT ["dumb-init", "--"]
 
 CMD /usr/bin/php \
     -d memory_limit=$MEMORY \

--- a/adminer-postgres/Dockerfile
+++ b/adminer-postgres/Dockerfile
@@ -15,13 +15,16 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         ca-certificates \
         php7@testing \
         php7-session@testing \
-        php7-pgsql@testing && \
+        php7-pgsql@testing \
+        dumb-init && \
     wget https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php -O /srv/index.php && \
     apk del wget ca-certificates && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /srv
 EXPOSE 80
+
+ENTRYPOINT ["dumb-init", "--"]
 
 CMD /usr/bin/php \
     -d memory_limit=$MEMORY \


### PR DESCRIPTION
fixes https://github.com/dockette/adminer/issues/30

I did not fix the oracle Dockerfiles, because they're Debian based and my first try did not work for them when I tested this. However all the others are fixed and are now stopping properly (and almost immediately).