### PR TITLE
Fix dockette/adminer:dg

### DIFF
--- a/adminer-dg/Dockerfile
+++ b/adminer-dg/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 
 LABEL maintainer="Milan Sulc <sulcmil@gmail.com>"
 
-ENV ADMINER_DG_VERION=1.18.0
+ENV ADMINER_DG_VERION=1.28.0
 ENV MEMORY=256M
 ENV UPLOAD=2048M
 ENV WORKERS=4


### PR DESCRIPTION
The latest version of dockette/adminer:dg is broken:

```
 Uncaught Error: Call to undefined function get_magic_quotes_gpc() in /srv/adminer.php:20
```

It seems to have been fixed in dg/adminer-custom v1.25.0.

It seems you had a newer version but somehow reverted it in https://github.com/dockette/adminer/commit/85cbb474e8a509ddfd05fab6cf08cc37d7c1ec0f#diff-e3f15fb16d00a3ab10472932158657a702cc4afbf4f5e5f4618ad83c66483d74.