### PR TITLE
CI: add rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -205,16 +205,16 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     name: Docs
+    needs: build
+    if: ${{ github.ref == 'refs/heads/master' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Validate README
-        run: |
-          test -s README.md
-          grep -F 'https://github.com/dockette/adminer/actions/workflows/docker.yml/badge.svg' README.md
-          grep -F 'https://img.shields.io/docker/pulls/dockette/adminer.svg' README.md
-          grep -F 'https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa' README.md
-          grep -F 'https://img.shields.io/badge/support-discussions-6f42c1' README.md
-          ! grep -Ei 'slack|join\.slack|gitter|badgen\.net' README.md
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: dockette/adminer

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  docker:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -75,7 +75,7 @@ jobs:
             tag: latest
             platforms: linux/amd64,linux/arm64
 
-    name: Docker (dockette/adminer:${{ matrix.tag }})
+    name: Test (dockette/adminer:${{ matrix.tag }})
 
     steps:
       - name: Checkout
@@ -86,13 +86,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-
-      - name: Login to DockerHub
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image for testing (linux/amd64)
         uses: docker/build-push-action@v7
@@ -113,18 +106,115 @@ jobs:
       - name: Test HTTP server
         run: |
           CONTAINER_ID=$(docker run -d --rm -p 8080:80 dockette/adminer:${{ matrix.tag }}-test)
+          trap 'docker stop $CONTAINER_ID' EXIT
           sleep 5
           curl -f http://localhost:8080 | grep -i "adminer" || (docker logs $CONTAINER_ID && exit 1)
-          docker stop $CONTAINER_ID
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./adminer-dg/Dockerfile
+            context: .
+            tag: dg
+            platforms: linux/amd64,linux/arm64
+
+          - dockerfile: ./adminer-editor/Dockerfile
+            context: .
+            tag: editor
+            platforms: linux/amd64,linux/arm64
+
+          - dockerfile: ./adminer-full/Dockerfile
+            context: .
+            tag: full
+            platforms: linux/amd64,linux/arm64
+
+          - dockerfile: ./adminer-mongo/Dockerfile
+            context: .
+            tag: mongo
+            platforms: linux/amd64,linux/arm64
+
+          - dockerfile: ./adminer-mssql/Dockerfile
+            context: .
+            tag: mssql
+            platforms: linux/amd64
+
+          - dockerfile: ./adminer-mysql/Dockerfile
+            context: .
+            tag: mysql
+            platforms: linux/amd64,linux/arm64
+
+          - dockerfile: ./adminer-oracle-11/Dockerfile
+            context: .
+            tag: oracle-11
+            platforms: linux/amd64
+
+          - dockerfile: ./adminer-oracle-12/Dockerfile
+            context: .
+            tag: oracle-12
+            platforms: linux/amd64
+
+          - dockerfile: ./adminer-oracle-19/Dockerfile
+            context: .
+            tag: oracle-19
+            platforms: linux/amd64
+
+          - dockerfile: ./adminer-postgres/Dockerfile
+            context: .
+            tag: postgres
+            platforms: linux/amd64,linux/arm64
+
+          - dockerfile: ./adminer-full/Dockerfile
+            context: .
+            tag: latest
+            platforms: linux/amd64,linux/arm64
+
+    name: Build (dockette/adminer:${{ matrix.tag }})
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push to registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
           tags: dockette/adminer:${{ matrix.tag }}
           platforms: ${{ matrix.platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  docs:
+    runs-on: ubuntu-latest
+    name: Docs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate README
+        run: |
+          test -s README.md
+          grep -F 'https://github.com/dockette/adminer/actions/workflows/docker.yml/badge.svg' README.md
+          grep -F 'https://img.shields.io/docker/pulls/dockette/adminer.svg' README.md
+          grep -F 'https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa' README.md
+          grep -F 'https://img.shields.io/badge/support-discussions-6f42c1' README.md
+          ! grep -Ei 'slack|join\.slack|gitter|badgen\.net' README.md

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 DOCKER_IMAGE=dockette/adminer
 DOCKER_PLATFORMS?=linux/amd64
+DOCKER_RUN_PORT?=8000
+DOCKER_RUN_TAG?=full
 
-build-all: build-full build-dg build-editor build-mongo build-mysql build-postgres build-oracle-11 build-oracle-12 build-oracle-19
+build: build-all
+
+test: test-all
+
+run:
+	docker run --rm -it -p ${DOCKER_RUN_PORT}:80 ${DOCKER_IMAGE}:${DOCKER_RUN_TAG}
+
+build-all: build-full build-dg build-editor build-mongo build-mssql build-mysql build-postgres build-oracle-11 build-oracle-12 build-oracle-19
 
 _docker-build-%: TAG=$*
 _docker-build-%:
@@ -11,6 +20,7 @@ build-full: _docker-build-full
 build-dg: _docker-build-dg
 build-editor: _docker-build-editor
 build-mongo: _docker-build-mongo
+build-mssql: _docker-build-mssql
 build-mysql: _docker-build-mysql
 build-postgres: _docker-build-postgres
 build-oracle-11: _docker-build-oracle-11
@@ -25,13 +35,29 @@ test-full: _docker-test-full
 test-dg: _docker-test-dg
 test-editor: _docker-test-editor
 test-mongo: _docker-test-mongo
+test-mssql: _docker-test-mssql
 test-mysql: _docker-test-mysql
 test-postgres: _docker-test-postgres
 test-oracle-11: _docker-test-oracle-11
 test-oracle-12: _docker-test-oracle-12
 test-oracle-19: _docker-test-oracle-19
 
-test-all: test-full test-dg test-editor test-mongo test-mysql test-postgres test-oracle-11 test-oracle-12 test-oracle-19
+test-all: test-full test-dg test-editor test-mongo test-mssql test-mysql test-postgres test-oracle-11 test-oracle-12 test-oracle-19
+
+_docker-run-%: TAG=$*
+_docker-run-%:
+	docker run --rm -it -p ${DOCKER_RUN_PORT}:80 ${DOCKER_IMAGE}:${TAG}
+
+run-full: _docker-run-full
+run-dg: _docker-run-dg
+run-editor: _docker-run-editor
+run-mongo: _docker-run-mongo
+run-mssql: _docker-run-mssql
+run-mysql: _docker-run-mysql
+run-postgres: _docker-run-postgres
+run-oracle-11: _docker-run-oracle-11
+run-oracle-12: _docker-run-oracle-12
+run-oracle-19: _docker-run-oracle-19
 
 update-versions:
 	find . -type f -name Dockerfile -exec sed -i '' 's/ENV ADMINER_VERSION=.*/ENV ADMINER_VERSION=${ADMINER_VERSION}/g' {} +

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 </p>
 
 <p align=center>
-  <a href="https://hub.docker.com/r/dockette/adminer/"><img src="https://badgen.net/docker/pulls/dockette/adminer"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://github.com/sponsors/f3l1x"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
+   <a href="https://github.com/dockette/adminer/actions"><img src="https://github.com/dockette/adminer/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/adminer"><img src="https://img.shields.io/docker/pulls/dockette/adminer.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
 </p>
 
 ![Adminer](.docs/assets/adminer.png)
@@ -222,4 +223,4 @@ ADMINER_VERSION=4.8.1 make update-versions
 
 ## Maintenance
 
-See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.


### PR DESCRIPTION
What changed
- Split the Docker workflow into clear Test, Build, and Docs jobs while keeping the existing image matrix.
- Added canonical Makefile aliases for build, test, and run, including the MSSQL variant.
- Normalized README badges to the Dockette Copybara style and completed the standard Maintenance section.

Why
- Aligns dockette/adminer with the Dockette CI rollout baseline while preserving variant-specific build and test targets.